### PR TITLE
Add Xid to all messages

### DIFF
--- a/wal2json.c
+++ b/wal2json.c
@@ -964,6 +964,9 @@ pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 	escape_json(ctx->out, NameStr(class_form->relname));
 	appendStringInfo(ctx->out, ",%s", data->nl);
 
+	appendStringInfo(ctx->out, "\"xid\":%u", txn->xid);
+	appendStringInfo(ctx->out, ",");
+
 	switch (change->action)
 	{
 		case REORDER_BUFFER_CHANGE_INSERT:


### PR DESCRIPTION
This adds the xid on all messages. Not only begin and commit.

`{  
   "change":[
      {  
         "kind":"update",
         "schema":"public",
         "table":"sentry_option",
         "xid":257644,
         "columnnames":[  
            "id",
            "key",
            "value",
            "last_updated"
         ],
         "columntypes":[  
            "bigint",
            "character varying(64)",
            "text",
            "timestamp with time zone"
         ],
         "columnvalues":[  
            2,
            "sentry:last_worker_version",
            "gAJYCwAAADEwLjAuMC5kZXYwcQEu",
            "2019-05-16 21:42:17.065328+00"
         ],
         "oldkeys":{  
            "keynames":[  
               "id"
            ],
            "keytypes":[  
               "bigint"
            ],
            "keyvalues":[  
               2
            ]
         }
      }
   ]
}`