### PR TITLE
feat(msg_header) Add message header including the table name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ MODULES = wal2json
 # message test will fail for <= 9.5
 REGRESS = cmdline insert1 update1 update2 update3 update4 delete1 delete2 \
 		  delete3 delete4 savepoint specialvalue toast bytea message typmod \
-		  filtertable selecttable include_timestamp include_lsn include_xids
+		  filtertable selecttable include_timestamp include_lsn include_xids \
+		  include_header
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/expected/include_header.out
+++ b/expected/include_header.out
@@ -1,0 +1,35 @@
+\set VERBOSITY terse
+-- predictability
+SET synchronous_commit = on;
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+ ?column? 
+----------
+ init
+(1 row)
+
+-- Insert one row and check header
+INSERT INTO tbl VALUES (1);
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1', 'include-message-header', '1');
+                data                 
+-------------------------------------
+ B|{"event":"begin"}
+ M|tbl|{                            +
+         "event": "change",         +
+         "kind": "insert",          +
+         "schema": "public",        +
+         "table": "tbl",            +
+         "columnnames": ["id"],     +
+         "columntypes": ["integer"],+
+         "columnvalues": [1]        +
+ }
+ C|{"event":"commit"}
+(3 rows)
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+ ?column? 
+----------
+ stop
+(1 row)
+

--- a/sql/include_header.sql
+++ b/sql/include_header.sql
@@ -1,0 +1,17 @@
+\set VERBOSITY terse
+
+-- predictability
+SET synchronous_commit = on;
+
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (id int);
+
+SELECT 'init' FROM pg_create_logical_replication_slot('regression_slot', 'wal2json');
+
+-- Insert one row and check header
+
+INSERT INTO tbl VALUES (1);
+SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'pretty-print', '1', 'include-message-header', '1');
+
+SELECT 'stop' FROM pg_drop_replication_slot('regression_slot');
+

--- a/wal2json.c
+++ b/wal2json.c
@@ -28,12 +28,12 @@
 #define	WAL2JSON_FORMAT_VERSION			1
 #define	WAL2JSON_FORMAT_MIN_VERSION		1
 
-#define WAL2JSON_BEGIN_MSG_TYPE			'B'
-#define WAL2JSON_COMMIT_MSG_TYPE		'C'
-#define WAL2JSON_MODIFY_MSG_TYPE		'M'
-#define WAL2JSON_GENERIC_MSG_TYPE		'G'
+#define WAL2JSON_BEGIN_MSG_TYPE	        'B'
+#define WAL2JSON_COMMIT_MSG_TYPE        'C'
+#define WAL2JSON_MODIFY_MSG_TYPE        'M'
+#define WAL2JSON_GENERIC_MSG_TYPE       'G'
 
-#define WAL2JSON_META_SEPARATOR			'|'
+#define WAL2JSON_META_SEPARATOR	        '|'
 
 PG_MODULE_MAGIC;
 
@@ -108,25 +108,25 @@ static bool string_to_SelectTable(char *rawstring, char separator, List **select
 static void
 init_message(LogicalDecodingContext *ctx, char msg_type, char *header)
 {
-	JsonDecodingData *data = ctx->output_plugin_private;
-	OutputPluginPrepareWrite(ctx, true);
-	if (data->include_message_header) {
-		appendStringInfo(ctx->out, "%c%c", msg_type, WAL2JSON_META_SEPARATOR);
-		if (header != NULL) {
-			int i;
-			for(i = 0; i < strlen(header); i++) {
-				char c = header[i];
-				if (c == '|') {
-					appendStringInfo(ctx->out, "\\|");
-				} else if (c == '\\') {
-					appendStringInfo(ctx->out, "\\\\");
-				} else {
-					appendStringInfoChar(ctx->out, c);
-				}
-			}
-			appendStringInfoChar(ctx->out, '|');
-		}
-	}
+    JsonDecodingData *data = ctx->output_plugin_private;
+    OutputPluginPrepareWrite(ctx, true);
+    if (data->include_message_header) {
+        appendStringInfo(ctx->out, "%c%c", msg_type, WAL2JSON_META_SEPARATOR);
+        if (header != NULL) {
+            int i;
+            for(i = 0; i < strlen(header); i++) {
+                char c = header[i];
+                if (c == '|') {
+                    appendStringInfo(ctx->out, "\\|");
+                } else if (c == '\\') {
+                    appendStringInfo(ctx->out, "\\\\");
+                } else {
+                    appendStringInfoChar(ctx->out, c);
+                }
+            }
+            appendStringInfoChar(ctx->out, '|');
+        }
+    }
 }
 
 void

--- a/wal2json.c
+++ b/wal2json.c
@@ -108,8 +108,8 @@ static bool string_to_SelectTable(char *rawstring, char separator, List **select
 static void
 init_message(LogicalDecodingContext *ctx, char msg_type, char *header)
 {
-	OutputPluginPrepareWrite(ctx, true);
 	JsonDecodingData *data = ctx->output_plugin_private;
+	OutputPluginPrepareWrite(ctx, true);
 	if (data->include_message_header) {
 		appendStringInfo(ctx->out, "%c%c", msg_type, WAL2JSON_META_SEPARATOR);
 		if (header != NULL) {

--- a/wal2json.c
+++ b/wal2json.c
@@ -116,15 +116,15 @@ init_message(LogicalDecodingContext *ctx, char msg_type, char *header)
             int i;
             for(i = 0; i < strlen(header); i++) {
                 char c = header[i];
-                if (c == '|') {
-                    appendStringInfo(ctx->out, "\\|");
+                if (c == WAL2JSON_META_SEPARATOR) {
+                    appendStringInfo(ctx->out, "\\%c", WAL2JSON_META_SEPARATOR);
                 } else if (c == '\\') {
                     appendStringInfo(ctx->out, "\\\\");
                 } else {
                     appendStringInfoChar(ctx->out, c);
                 }
             }
-            appendStringInfoChar(ctx->out, '|');
+            appendStringInfoChar(ctx->out, WAL2JSON_META_SEPARATOR);
         }
     }
 }


### PR DESCRIPTION
Adds a message headers in the form of `<MSG_TYPE>|<HEADER>|<JSON>`
A header is a string any message specific function can define (for mutations we add the table name).
The goal is to be able to allow consumers to extract some meta data regarding messages and make sense of them without having to parse the entire json, which can be a performance issue if most messages are not interesting to the consumer.

The format is text based since the plugin right now is expected to produce plain text output. We could turn everything to binary if we wanted.

Added a test for this specific case.