### PR TITLE
Release the wal2json binary for both musl and glibc

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -17,4 +17,5 @@ targets:
   - name: github
 
 requireNames:
-  - /^wal2json-Linux-x86_64.so$/
+  - /^wal2json-Linux-x86_64-musl.so$/
+  - /^wal2json-Linux-x86_64-glibc.so$/

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -11,6 +11,9 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        libc: [musl, glibc]
   
     steps:
       - uses: actions/checkout@v2
@@ -20,15 +23,15 @@ jobs:
         run: >
           docker build
           --build-arg DOCKER_ARCH=amd64
-          -t getsentry/postgres_wal2json:build
-          -f Dockerfile.builder .
+          -t getsentry/postgres_wal2json_${{ matrix.libc }}:build
+          -f build/Dockerfile.builder.${{ matrix.libc }} .
       - name: Build in Docker (x86-64)
         run: >
           docker run
           -e DOCKER_ARCH=amd64
           -v `pwd`:/workspace
-          getsentry/postgres_wal2json:build
+          getsentry/postgres_wal2json_${{ matrix.libc }}:build
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
-          path: wal2json-Linux-x86_64.so
+          path: wal2json-Linux-x86_64-${{ matrix.libc }}.so

--- a/build/Dockerfile.builder.glibc
+++ b/build/Dockerfile.builder.glibc
@@ -1,0 +1,30 @@
+ARG DOCKER_ARCH=amd64
+
+# Used to build the wal2json library in a GHA. This image should 
+# almost never change. We do not need to build it every time.
+# We would mount the working directory with the source (that's the
+# part that changes) and run the build process on a running container
+
+# This builds a library that depends on glibc
+FROM $DOCKER_ARCH/postgres:9.6
+
+RUN set -ex; \
+    \
+    buildDeps=' \
+        gcc \
+        make \
+        libc6-dev \
+        pkgconf \
+        diffutils \
+        postgresql-server-dev-9.6 \
+    '; \
+    apt-get update; \
+    apt-get install -y $buildDeps --no-install-recommends; \
+    \
+    rm -rf /var/lib/apt/lists/*;
+
+ENV DOCKER_ARCH=$DOCKER_ARCH
+ENV LIBC_VERSION="glibc"
+
+WORKDIR /workspace
+ENTRYPOINT [ "./build/docker-entrypoint.sh" ]

--- a/build/Dockerfile.builder.musl
+++ b/build/Dockerfile.builder.musl
@@ -5,10 +5,12 @@ ARG DOCKER_ARCH=amd64
 # We would mount the working directory with the source (that's the
 # part that changes) and run the build process on a running container
 
+# This builds a library that depends on musl
 FROM $DOCKER_ARCH/postgres:9.6-alpine
 RUN apk add --no-cache --virtual .build-deps gcc make musl-dev pkgconf diffutils
 
 ENV DOCKER_ARCH=$DOCKER_ARCH
+ENV LIBC_VERSION="musl"
 
 WORKDIR /workspace
-ENTRYPOINT [ "./docker-entrypoint.sh" ]
+ENTRYPOINT [ "./build/docker-entrypoint.sh" ]

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -8,4 +8,4 @@ else
 fi
 
 make
-mv wal2json.so /workspace/wal2json-Linux-$BUILD_ARCH.so
+mv wal2json.so /workspace/wal2json-Linux-$BUILD_ARCH-$LIBC_VERSION.so


### PR DESCRIPTION
The current github action builds a wal2json binary to release through postgres-alpine. This is fine as long as we run postgres-alpine. It breaks if we run the standard postgres container. 
The issue is due to postgres-alpine relying having musl installed as libc instead of glibc. 

This is what happens when trying to use the library built by postgres alpine.

On postgres-alpine

```
bash-5.1# ldd /wal2json/latest.so 
        /lib/ld-musl-x86_64.so.1 (0x7effc8ba9000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7effc8ba9000)
```

On postgres

```
root@1bca1c71f616:/usr/lib/postgresql/9.6/lib# ldd wal2json.so 
        linux-vdso.so.1 (0x00007ffd30348000)
        libc.musl-x86_64.so.1 => not found
```

So this solution duplicates the build steps to release one binary that depends on musl and another that depends on glibc.